### PR TITLE
Fix for removal entities events:

### DIFF
--- a/Model/CreateRemoveEventTypePayload.php
+++ b/Model/CreateRemoveEventTypePayload.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trilix\EventsApiBundle\Model;
+
+use Assert\Assert;
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+
+class CreateRemoveEventTypePayload
+{
+    /**
+     * @param GenericEventInterface $event
+     * @return array
+     */
+    public function __invoke(GenericEventInterface $event): array
+    {
+        /** @var CategoryInterface|AttributeInterface|FamilyInterface|ProductModelInterface $entity */
+        $entity = $event->getSubject();
+
+        assert::that($entity)->propertyExists('code');
+        return ['code' => $entity->getCode()];
+    }
+}

--- a/Model/CreateRemoveProductEventTypePayload.php
+++ b/Model/CreateRemoveProductEventTypePayload.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trilix\EventsApiBundle\Model;
+
+use Assert\Assert;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+
+class CreateRemoveProductEventTypePayload
+{
+    /**
+     * @param GenericEventInterface $event
+     * @return array
+     */
+    public function __invoke(GenericEventInterface $event): array
+    {
+        /** @var ProductInterface $product */
+        $product = $event->getSubject();
+
+        assert::that($product)->propertyExists('identifier');
+        return ['identifier' => $product->getIdentifier()];
+    }
+}

--- a/Model/PimEventTypeConfigurationFactories.php
+++ b/Model/PimEventTypeConfigurationFactories.php
@@ -45,10 +45,10 @@ class PimEventTypeConfigurationFactories
     }
 
     /**
-     * @param CreateEventTypePayload $createEventTypePayload
+     * @param CreateRemoveEventTypePayload $createEventTypePayload
      * @return EventTypeConfigurationInterface
      */
-    public static function categoryRemovedEventTypeConfiguration(CreateEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
+    public static function categoryRemovedEventTypeConfiguration(CreateRemoveEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
     {
         return new EventTypeConfiguration(
             EntityEventTypes::CATEGORY_REMOVED,
@@ -90,10 +90,10 @@ class PimEventTypeConfigurationFactories
     }
 
     /**
-     * @param CreateEventTypePayload $createEventTypePayload
+     * @param CreateRemoveEventTypePayload $createEventTypePayload
      * @return EventTypeConfigurationInterface
      */
-    public static function attributeRemovedEventTypeConfiguration(CreateEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
+    public static function attributeRemovedEventTypeConfiguration(CreateRemoveEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
     {
         return new EventTypeConfiguration(
             EntityEventTypes::ATTRIBUTE_REMOVED,
@@ -135,10 +135,10 @@ class PimEventTypeConfigurationFactories
     }
 
     /**
-     * @param CreateEventTypePayload $createEventTypePayload
+     * @param CreateRemoveEventTypePayload $createEventTypePayload
      * @return EventTypeConfigurationInterface
      */
-    public static function familyRemovedEventTypeConfiguration(CreateEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
+    public static function familyRemovedEventTypeConfiguration(CreateRemoveEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
     {
         return new EventTypeConfiguration(
             EntityEventTypes::FAMILY_REMOVED,
@@ -180,10 +180,10 @@ class PimEventTypeConfigurationFactories
     }
 
     /**
-     * @param CreateEventTypePayload $createEventTypePayload
+     * @param CreateRemoveProductEventTypePayload $createEventTypePayload
      * @return EventTypeConfigurationInterface
      */
-    public static function productRemovedEventTypeConfiguration(CreateEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
+    public static function productRemovedEventTypeConfiguration(CreateRemoveProductEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
     {
         return new EventTypeConfiguration(
             EntityEventTypes::PRODUCT_REMOVED,
@@ -225,10 +225,10 @@ class PimEventTypeConfigurationFactories
     }
 
     /**
-     * @param CreateEventTypePayload $createEventTypePayload
+     * @param CreateRemoveEventTypePayload $createEventTypePayload
      * @return EventTypeConfigurationInterface
      */
-    public static function productModelRemovedEventTypeConfiguration(CreateEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
+    public static function productModelRemovedEventTypeConfiguration(CreateRemoveEventTypePayload $createEventTypePayload): EventTypeConfigurationInterface
     {
         return new EventTypeConfiguration(
             EntityEventTypes::PRODUCT_MODEL_REMOVED,

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ Events API sends one request per one event, and sending of requests happens in r
 | --------------------- |:----------------------------------:|
 | category_created      | New category was created           |
 | category_updated      | Existing category was updated      |
-| category_deleted      | Existing category was deleted      |
+| category_removed      | Existing category was deleted      |
 | attribute_created     | New attribute was created          |
 | attribute_updated     | Existing attribute was updated     |
-| attribute_deleted     | Existing attribute was deleted     |
+| attribute_removed     | Existing attribute was deleted     |
 | family_created        | New family was created             |
 | family_updated        | Existing family was updated        |
-| family_created        | Existing family was deleted        |
+| family_removed        | Existing family was deleted        |
 | product_created       | New product was created            |
 | product_updated       | Existing product was updated       |
-| product_deleted       | Existing product was deleted       |
+| product_removed       | Existing product was deleted       |
 | product_model_created | New product model was created      |
 | product_model_updated | Existing product model was updated |
-| product_model_deleted | Existing product model was deleted |
+| product_model_removed | Existing product model was deleted |
 
 ### Example of *category_updated* event
 
@@ -109,13 +109,23 @@ Events API sends one request per one event, and sending of requests happens in r
   "event_time": 1565021907
 }
 ```
+### Example of *product_model_removed* event
+```json
+{
+  "event_type": "product_model_removed",
+  "payload": {
+    "code": "derby"
+  },
+  "event_time": 1579792377
+}
+```
 
 ### Event Type Structure
 
 | Field        | Type | Description                                                                                 |
 | ------------ |:-------:|:----------------------------------------------------------------------------------------:|
 | *event_type* | String  | Type of event which happened (see [event types](#Event-types-delivered-over-Events-API)) |
-| *payload*    | Object  | Contains information which represents the event                                          |
+| *payload*    | Object  | Contains information which represents the event. For events related to deletion of entity it contains entity only identifier (identifier value for Products and code for all others) |
 | *event_time* | Integer | Timestamp in seconds when the event was created                                          |
 
 ### Attention :heavy_exclamation_mark:

--- a/Resources/config/events.yml
+++ b/Resources/config/events.yml
@@ -13,7 +13,7 @@ services:
 
     pim_events_api.event_type_configuration.category_removed:
         factory: ['Trilix\EventsApiBundle\Model\PimEventTypeConfigurationFactories', 'categoryRemovedEventTypeConfiguration']
-        arguments: ['@pim_events_api.create_event_type_payload']
+        arguments: ['@pim_events_api.create_remove_event_type_payload']
         tags:
             - { name: 'pim_events_api.event_type_configuration' }
 
@@ -31,7 +31,7 @@ services:
 
     pim_events_api.event_type_configuration.attribute_removed:
         factory: ['Trilix\EventsApiBundle\Model\PimEventTypeConfigurationFactories', 'attributeRemovedEventTypeConfiguration']
-        arguments: ['@pim_events_api.create_event_type_payload']
+        arguments: ['@pim_events_api.create_remove_event_type_payload']
         tags:
             - { name: 'pim_events_api.event_type_configuration' }
 
@@ -49,7 +49,7 @@ services:
 
     pim_events_api.event_type_configuration.family_removed:
         factory: ['Trilix\EventsApiBundle\Model\PimEventTypeConfigurationFactories', 'familyRemovedEventTypeConfiguration']
-        arguments: ['@pim_events_api.create_event_type_payload']
+        arguments: ['@pim_events_api.create_remove_event_type_payload']
         tags:
             - { name: 'pim_events_api.event_type_configuration' }
 
@@ -67,7 +67,7 @@ services:
 
     pim_events_api.event_type_configuration.product_removed:
         factory: ['Trilix\EventsApiBundle\Model\PimEventTypeConfigurationFactories', 'productRemovedEventTypeConfiguration']
-        arguments: ['@pim_events_api.create_event_type_payload']
+        arguments: ['@pim_events_api.create_remove_product_event_type_payload']
         tags:
             - { name: 'pim_events_api.event_type_configuration' }
 
@@ -85,6 +85,6 @@ services:
 
     pim_events_api.event_type_configuration.product_model_removed:
         factory: ['Trilix\EventsApiBundle\Model\PimEventTypeConfigurationFactories', 'productModelRemovedEventTypeConfiguration']
-        arguments: ['@pim_events_api.create_event_type_payload']
+        arguments: ['@pim_events_api.create_remove_event_type_payload']
         tags:
             - { name: 'pim_events_api.event_type_configuration' }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,8 @@ parameters:
     pim_events_api.events_handler.class: Trilix\EventsApiBundle\Model\EventsHandler
     pim_events_api.outer_event_builder.class: Trilix\EventsApiBundle\OuterEvent\OuterEventBuilder
     pim_events_api.create_event_type_payload.class: Trilix\EventsApiBundle\Model\CreateEventTypePayload
+    pim_events_api.create_remove_product_event_type_payload.class: Trilix\EventsApiBundle\Model\CreateRemoveProductEventTypePayload
+    pim_events_api.create_remove_event_type_payload.class: Trilix\EventsApiBundle\Model\CreateRemoveEventTypePayload
     pim_events_api.resolve_event_type.class: Trilix\EventsApiBundle\Model\ResolveEventType
     pim_events_api.event_type_configuration_list.class: Trilix\EventsApiBundle\Model\EventTypeConfigurationList
     pim_events_api.akeneo_batch_outer_event_dispatcher.class: Trilix\EventsApiBundle\Model\AkeneoBatchOuterEventDispatcher
@@ -53,6 +55,12 @@ services:
         class: '%pim_events_api.create_event_type_payload.class%'
         arguments:
             - '@pim_external_api_serializer'
+
+    pim_events_api.create_remove_product_event_type_payload:
+        class: '%pim_events_api.create_remove_product_event_type_payload.class%'
+
+    pim_events_api.create_remove_event_type_payload:
+        class: '%pim_events_api.create_remove_event_type_payload.class%'
 
     pim_events_api.event_type_configuration_list:
         class: '%pim_events_api.event_type_configuration_list.class%'

--- a/Tests/Unit/EventSubscriber/AkeneoStorageUtilsSubscriberTest.php
+++ b/Tests/Unit/EventSubscriber/AkeneoStorageUtilsSubscriberTest.php
@@ -27,7 +27,10 @@ class AkeneoStorageUtilsSubscriberTest extends TestCase
     /** @var LoggerInterface|MockObject */
     private $logger;
 
-    protected function setUp()
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->eventsHandler = $this->createMock(EventsHandler::class);

--- a/Tests/Unit/Model/AkeneoBatchOuterEventDispatcherTest.php
+++ b/Tests/Unit/Model/AkeneoBatchOuterEventDispatcherTest.php
@@ -29,7 +29,10 @@ class AkeneoBatchOuterEventDispatcherTest extends TestCase
     /** @var AkeneoBatchOuterEventDispatcher */
     private $dispatcher;
 
-    protected function setUp()
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
@@ -77,6 +80,7 @@ class AkeneoBatchOuterEventDispatcherTest extends TestCase
 
     /**
      * @test
+     * @throws \ReflectionException
      */
     public function launchesJob(): void
     {

--- a/Tests/Unit/Model/CreateEventTypePayloadTest.php
+++ b/Tests/Unit/Model/CreateEventTypePayloadTest.php
@@ -21,7 +21,10 @@ class CreateEventTypePayloadTest extends TestCase
     /** @var SerializerInterface|NormalizerInterface|MockObject */
     private $serializer;
 
-    protected function setUp()
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->serializer = $this->createMock(NormalizerInterface::class);

--- a/Tests/Unit/Model/CreateRemoveEventTypePayloadTest.php
+++ b/Tests/Unit/Model/CreateRemoveEventTypePayloadTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trilix\EventsApiBundle\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Assert\InvalidArgumentException;
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
+use Akeneo\Pim\Structure\Component\Model\Attribute;
+use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Trilix\EventsApiBundle\Model\CreateRemoveEventTypePayload;
+use Trilix\EventsApiBundle\Model\GenericRemoveEntityEventInterface;
+
+class CreateRemoveEventTypePayloadTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider supportedEventsDataProvider
+     *
+     * @param $event
+     * @param $entityCode
+     */
+    public function createsPayload($event, $entityCode): void
+    {
+        $expectedPayload = ['code' => $entityCode];
+
+        $actualPayload = (new CreateRemoveEventTypePayload())->__invoke($event);
+        self::assertSame($expectedPayload, $actualPayload);
+    }
+
+    /**
+     * @test
+     */
+    public function throwsInvalidArgumentExceptionIfSubjectDoesNotContainsCodeProperty(): void
+    {
+        $removeProductEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Product
+            {
+                return (new Product());
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+
+        (new CreateRemoveEventTypePayload())->__invoke($removeProductEvent);
+    }
+
+    /**
+     * @return array
+     */
+    public function supportedEventsDataProvider(): array
+    {
+        $removeCategoryEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Category
+            {
+                return (new Category())->setCode('categoryCode');
+            }
+        };
+
+        $removeAttributeEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Attribute
+            {
+                return (new Attribute())->setCode('attributeCode');
+            }
+        };
+
+        $removeFamilyEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Family
+            {
+                return (new Family())->setCode('familyCode');
+            }
+        };
+
+        $removeProductModelEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): ProductModel
+            {
+                $productModel = new ProductModel();
+                $productModel->setCode('productModelCode');
+                return $productModel;
+            }
+        };
+
+        return [
+            [$removeCategoryEvent, 'categoryCode'],
+            [$removeAttributeEvent, 'attributeCode'],
+            [$removeFamilyEvent, 'familyCode'],
+            [$removeProductModelEvent, 'productModelCode']
+        ];
+    }
+}

--- a/Tests/Unit/Model/CreateRemoveProductEventTypePayloadTest.php
+++ b/Tests/Unit/Model/CreateRemoveProductEventTypePayloadTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trilix\EventsApiBundle\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Assert\InvalidArgumentException;
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
+use Akeneo\Pim\Structure\Component\Model\Attribute;
+use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
+use Trilix\EventsApiBundle\Model\CreateRemoveProductEventTypePayload;
+use Trilix\EventsApiBundle\Model\GenericRemoveEntityEventInterface;
+
+class CreateRemoveProductEventTypePayloadTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function createsPayload(): void
+    {
+        $removeProductEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Product
+            {
+                return (new Product())->setIdentifier(ScalarValue::value('sku', 'test-123'));
+            }
+        };
+
+        $expectedPayload = ['identifier' => 'test-123'];
+
+        $actualPayload = (new CreateRemoveProductEventTypePayload())->__invoke($removeProductEvent);
+        self::assertSame($expectedPayload, $actualPayload);
+    }
+
+    /**
+     * @test
+     * @dataProvider notSupportedEventsDataProvider
+     *
+     * @param $event
+     */
+    public function throwsInvalidArgumentExceptionIfSubjectDoesNotContainsIdentifierProperty($event): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new CreateRemoveProductEventTypePayload())->__invoke($event);
+    }
+
+    /**
+     * @return array
+     */
+    public function notSupportedEventsDataProvider(): array
+    {
+        $removeCategoryEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Category
+            {
+                return new Category();
+            }
+        };
+
+        $removeAttributeEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Attribute
+            {
+                return new Attribute();
+            }
+        };
+
+        $removeFamilyEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): Family
+            {
+                return new Family();
+            }
+        };
+
+        $removeProductModelEvent = new class implements GenericRemoveEntityEventInterface {
+            public function getSubject(): ProductModel
+            {
+                return new ProductModel();
+            }
+        };
+
+        return [
+            [$removeCategoryEvent],
+            [$removeAttributeEvent],
+            [$removeFamilyEvent],
+            [$removeProductModelEvent]
+        ];
+    }
+}

--- a/Tests/Unit/Model/EventsHandlerTest.php
+++ b/Tests/Unit/Model/EventsHandlerTest.php
@@ -35,7 +35,10 @@ class EventsHandlerTest extends TestCase
     /** @var LoggerInterface|MockObject */
     private $logger;
 
-    protected function setUp()
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->resolver = $this->createMock(ResolveEventType::class);


### PR DESCRIPTION
**Description (*)**

Events for types: product_removed and family_removed are not published. This happens because we used Akeneo normalization process for all events and entities in CreateEventTypePayload class:
```
    try {
        $payload = $this->serializer->normalize($entity, 'external_api');
    }
```
And for example when Product as entity is provided to normalize method (Remove product event), inside it there is also associations normalization happens. But because Product was deleted it does not contain id anymore, so error happens. That the reason why events for types: **product_removed** is not published.
Now we added possibility to define specific Event Type Payloads. This gives us possibility to define specific payload for all events and entities. In the case of removal it will contain entity only identifier (identifier value for Products and code for all others).
At the moment we've added we have 2 new classes for removal events:
* _CreateRemoveEventTypePayload_
* _CreateRemoveProductEventTypePayload_

**Fixed Issues**
1. Fixes #9 issue: Event with type product_removed not published
2. Fixes #7 issue: Event with type family_removed not published