### PR TITLE
Fix for empty values in payload

### DIFF
--- a/OuterEvent/OuterEvent.php
+++ b/OuterEvent/OuterEvent.php
@@ -73,7 +73,7 @@ class OuterEvent implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/OuterEvent/OuterEvent.php
+++ b/OuterEvent/OuterEvent.php
@@ -93,6 +93,13 @@ class OuterEvent implements JsonSerializable
         Assert::that($array['payload'])->isArray();
         Assert::that($array['event_time'])->integer();
 
-        return new self($array['event_type'], $array['payload'], $array['event_time']);
+        $payload = array_map(static function($element) {
+            if ((is_array($element)) && empty($element)) {
+                return (object) $element;
+            }
+            return $element;
+        }, $array['payload']);
+
+        return new self($array['event_type'], $payload, $array['event_time']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -92,21 +92,32 @@ Events API sends one request per one event, and sending of requests happens in r
 | product_model_updated | Existing product model was updated |
 | product_model_deleted | Existing product model was deleted |
 
-### Example of *category_updated* event
+### Example of *family_updated* event
 
 ```json
 {
-  "event_type": "category_updated",
-  "payload": {
-    "code": "cameras",
-    "labels": {
-      "de_DE": "Cameras",
-      "en_US": "Cameras new name",
-      "fr_FR": "Caméras"
+   "event_type": "family_updated",
+    "payload": {
+      "code": "test_family",
+      "labels": {},
+      "attributes": [
+        "sku"
+      ],
+      "attribute_as_image": null,
+      "attribute_as_label": "sku",
+      "attribute_requirements": {
+        "print": [
+          "sku"
+        ],
+        "mobile": [
+          "sku"
+        ],
+        "ecommerce": [
+          "sku"
+        ]
+      }
     },
-    "parent": "master"
-  },
-  "event_time": 1565021907
+    "event_time": 1579865355
 }
 ```
 

--- a/Tests/Unit/OuterEvent/OuterEventTest.php
+++ b/Tests/Unit/OuterEvent/OuterEventTest.php
@@ -72,13 +72,15 @@ class OuterEventTest extends TestCase
         $event = OuterEvent::fromArray(
             [
                 'event_type' => 'foo',
-                'payload' => ['foo' => 'payload'],
+                'payload' => ['foo' => 'payload', 'empty_values' => []],
                 'event_time' => $eventTime
             ]
         );
 
         self::assertSame('foo', $event->eventType());
-        self::assertSame(['foo' => 'payload'], $event->payload());
+        self::assertSame('payload', $event->payload()['foo']);
+        self::assertIsObject($event->payload()['empty_values']);
+        self::assertInstanceOf(\stdClass::class, $event->payload()['empty_values']);
         self::assertSame($eventTime, $event->eventTime());
     }
 }


### PR DESCRIPTION
**Description (*)**

The payload for events of types 
- **product_model_created** 
- **family_update**
- **family_create** 
- etc..

differs from the JSON returned by the Akeneo HTTP API. The reason is that Akeneo in some normalizers cast some empty array values to **object** type. For example look at Akeneo\Pim\Structure\Component\Normalizer\ExternalApi\FamilyNormalizer.php

``

    public function normalize($family, $format = null, array $context = [])
    {
        $normalizedFamily = $this->stdNormalizer->normalize($family, 'standard', $context);

        if (empty($normalizedFamily['labels'])) {
            $normalizedFamily['labels'] = (object) $normalizedFamily['labels'];
        }

        if (empty($normalizedFamily['attribute_requirements'])) {
            $normalizedFamily['attribute_requirements'] = (object) $normalizedFamily['attribute_requirements'];
        }

        return $normalizedFamily;
    }

From now we also cast nodes with empty arrays values to objects, so at the payload we receive {} instead of [];

**Fixed Issues**

Fixes #5 issue: Payload for family_upate and family_create differs from Akeneo API
Fixes #8  issue: Payload for event with type product_model_created differs from Akeneo API